### PR TITLE
Fix Taskfile.yaml with renaming of nuvolaris-config module

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -18,7 +18,7 @@
 version: '3'
 
 vars:
-  MODULES: controller runtimes operator cli admin testing
+  MODULES: controller runtimes operator cli config testing
   MILESTONE: neo
   IMAGE: nuvolaris/nuvolaris-devkit
   REPO: ghcr.io
@@ -70,7 +70,7 @@ tasks:
        - cmd: |
             for mod in {{.MODULES}}
             do if test -e $mod/Taskfile.yml
-               then task setup -d $mod
+            then echo "task setup $mod: "; task setup -d $mod
                fi
             done 
          ignore_error: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -70,7 +70,7 @@ tasks:
        - cmd: |
             for mod in {{.MODULES}}
             do if test -e $mod/Taskfile.yml
-            then echo "task setup $mod: "; task setup -d $mod
+               then task setup -d $mod
                fi
             done 
          ignore_error: true


### PR DESCRIPTION
This fix allows to run "task setup" on all the submodules, including nuvolaris-config.
Taskfile.yaml was still referring to nuvolaris-config as "admin", so "task setup" did not work on that module.
@michele-sciabarra could it be possible to merge this change?