### PR TITLE
Fix taskfile

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -18,7 +18,7 @@
 version: '3'
 
 vars:
-  MODULES: controller runtimes operator cli admin testing
+  MODULES: controller runtimes operator cli config testing
   MILESTONE: neo
   IMAGE: nuvolaris/nuvolaris-devkit
   REPO: ghcr.io
@@ -70,7 +70,7 @@ tasks:
        - cmd: |
             for mod in {{.MODULES}}
             do if test -e $mod/Taskfile.yml
-               then task setup -d $mod
+            then echo "task setup $mod: "; task setup -d $mod
                fi
             done 
          ignore_error: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -70,7 +70,7 @@ tasks:
        - cmd: |
             for mod in {{.MODULES}}
             do if test -e $mod/Taskfile.yml
-            then echo "task setup $mod: "; task setup -d $mod
+               then task setup -d $mod
                fi
             done 
          ignore_error: true


### PR DESCRIPTION
This change fixes the Taskfile not allowing "task setup" on nuvolaris-config submodule due to a missing update of the modue name.

I apologize for having duplicated my previous PR. It's my first PR and I closed the original one by mistake.

@michele-sciabarra, could it be possible to merge this change?