### PR TITLE
Fixed syntax in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
 // under the License.
 {
 	"name": "nuvolaris",
-	"image": "ghcr.io/nuvolaris/nuvolaris-devkit:0.3.0-morpheus.23011314"
+	"image": "ghcr.io/nuvolaris/nuvolaris-devkit:0.3.0-morpheus.23011314",
 	//"build": { "dockerfile": "Dockerfile" },
 	"mounts": [
 		"source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"


### PR DESCRIPTION
A typo in the `devcontainer.json` file prevented Github Codespaces from running correctly. 

