### PR TITLE
feature: install nuv cli via deb package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,9 +63,13 @@ RUN \
     URL="https://github.com/nuvolaris/nuv/releases/download/$BUILD/$FILE" ;\
     wget $URL -O "/tmp/nuv-installer/$FILE" ;\
     dpkg -i "/tmp/nuv-installer/$FILE"
-  RUN \
-    /usr/bin/echo -e '#!/bin/bash\nsudo env DOCKER_HOST=unix:///var/run/docker-host.sock /usr/nuvolaris/kind "$@"' >/usr/nuvolaris/kind ;\
-    chmod +x /usr/nuvolaris/kind   
+RUN \
+    VER="v0.14.0" ;\
+    ARCH="$(dpkg --print-architecture)" ;\
+    URL="https://github.com/kubernetes-sigs/kind/releases/download/$VER/kind-linux-$ARCH" ;\
+    wget $URL -O /usr/bin/kind.bin ;\
+    /usr/bin/echo -e '#!/bin/bash\nsudo env DOCKER_HOST=unix:///var/run/docker-host.sock /usr/bin/kind.bin "$@"' >/usr/bin/kind ;\
+    chmod +x /usr/bin/kind.bin /usr/bin/kind 
 RUN \
     VER="v1.26.1" ;\
     ARCH="$(dpkg --print-architecture)" ;\

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN \
 RUN \
     rm -Rvf /tmp/nuv-installer ;\
     mkdir /tmp/nuv-installer ;\
-    BUILD="0.3.0-morpheus.23042210" ;\
+    BUILD="0.3.0-morpheus.23042311" ;\
     ARCH="$(dpkg --print-architecture)" ;\
     FILE="nuv_$(echo $BUILD)_$ARCH.deb" ;\
     URL="https://github.com/nuvolaris/nuv/releases/download/$BUILD/$FILE" ;\

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,10 +55,17 @@ RUN \
     wget "https://github.com/dandavison/delta/releases/download/0.11.2/$FILE" -O "/tmp/$FILE" ;\
     dpkg -i "/tmp/$FILE" ; rm "/tmp/$FILE"
 RUN \
-    VER="v1.23.6" ;\
+    rm -Rvf /tmp/nuv-installer ;\
+    mkdir /tmp/nuv-installer ;\
+    BUILD="0.3.0-morpheus.23042210" ;\
     ARCH="$(dpkg --print-architecture)" ;\
-    URL="https://dl.k8s.io/release/$VER/bin/linux/$ARCH/kubectl" ;\
-    wget $URL -O /usr/bin/kubectl && chmod +x /usr/bin/kubectl
+    FILE="nuv_$(echo $BUILD)_$ARCH.deb" ;\
+    URL="https://github.com/nuvolaris/nuv/releases/download/$BUILD/$FILE" ;\
+    wget $URL -O "/tmp/nuv-installer/$FILE" ;\
+    dpkg -i "/tmp/nuv-installer/$FILE"
+  RUN \
+    /usr/bin/echo -e '#!/bin/bash\nsudo env DOCKER_HOST=unix:///var/run/docker-host.sock /usr/nuvolaris/kind "$@"' >/usr/nuvolaris/kind ;\
+    chmod +x /usr/nuvolaris/kind   
 RUN \
     VER="v1.26.1" ;\
     ARCH="$(dpkg --print-architecture)" ;\
@@ -69,13 +76,6 @@ RUN \
     ARCH="$(dpkg --print-architecture)" ;\
     URL="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F$VER/kustomize_${VER}_linux_${ARCH}.tar.gz" ;\
     curl -sL "$URL" | tar xzvf - -C /usr/bin
-RUN \
-    VER="v0.14.0" ;\
-    ARCH="$(dpkg --print-architecture)" ;\
-    URL="https://github.com/kubernetes-sigs/kind/releases/download/$VER/kind-linux-$ARCH" ;\
-    wget $URL -O /usr/bin/kind.bin ;\
-    /usr/bin/echo -e '#!/bin/bash\nsudo env DOCKER_HOST=unix:///var/run/docker-host.sock /usr/bin/kind.bin "$@"' >/usr/bin/kind ;\
-    chmod +x /usr/bin/kind.bin /usr/bin/kind
 RUN \
     ARCH="$(dpkg --print-architecture)" ;\
     VER=1.1.0 ;\
@@ -104,19 +104,10 @@ RUN \
     cd /tmp/helm ;\
     tar -zxvf "helm-${VER}-linux-${ARCH}.tar.gz" ;\
     mv "./linux-${ARCH}/helm" /usr/bin/helm ;\
-    rm -Rvf /tmp/helm
+    rm -Rvf /tmp/helm   
 RUN \
-    ARCH="$(dpkg --print-architecture)" ;\
-    MC_VER=RELEASE.2023-03-23T20-03-04Z; \
-    rm -Rvf /tmp/minio-binaries ;\
-    mkdir /tmp/minio-binaries ;\    
-    curl -sL "https://dl.min.io/client/mc/release/linux-${ARCH}/mc.${MC_VER}" --create-dirs -o /tmp/minio-binaries/mc ;\
-    chmod +x /tmp/minio-binaries/mc ;\
-    mv /tmp/minio-binaries/mc /usr/bin/mc;\
-    rm -Rvf /tmp/minio-binaries    
-RUN \
-    VER=4.11.0-0.okd-2022-08-20-022919 ;\
-    ARCH=$(dpkg --print-architecture) ;\
+    VER=4.12.0-0.okd-2023-04-16-041331 ;\
+    if dpkg --print-architecture | grep arm64 ; then VER="arm64-$VER" ; fi ;\
     BASE=https://github.com/okd-project/okd/releases/download/ ;\
     URL1="$BASE/$VER/openshift-install-linux-$VER.tar.gz" ;\
     URL2="$BASE/$VER/openshift-client-linux-$VER.tar.gz" ;\
@@ -138,13 +129,6 @@ RUN \
     URL="https://github.com/carvel-dev/ytt/releases/download/v0.40.4/ytt-linux-$ARCH" ;\
     curl -sL "$URL" >/usr/bin/ytt ;\
     chmod +x /usr/bin/ytt
-RUN \
-    VER=0.12.12 ;\
-    BASE=https://github.com/alexellis/k3sup/releases/download ;\
-    ARCH=-$(dpkg --print-architecture) ;\
-    if [[ $ARCH == "amd64" ]] ; then ARCH="" ; fi ;\
-    URL="$BASE/$VER/k3sup${ARCH}" ;\
-    curl -sL "$URL" >/usr/bin/k3sup ; chmod +x /usr/bin/k3sup
 RUN \
     VER="v1.4.1" ;\
     ARCH="$(dpkg --print-architecture)" ;\

--- a/cloud-init.yaml
+++ b/cloud-init.yaml
@@ -86,10 +86,14 @@ runcmd:
     URL="https://github.com/nuvolaris/nuv/releases/download/$BUILD/$FILE" ;\
     wget $URL -O "/tmp/nuv-installer/$FILE" ;\
     dpkg -i "/tmp/nuv-installer/$FILE"
-    - |
-    # setup a kind wrapper
-    /usr/bin/echo -e '#!/bin/bash\nsudo env DOCKER_HOST=unix:///var/run/docker-host.sock /usr/nuvolaris/kind "$@"' >/usr/nuvolaris/kind ;\
-    chmod +x /usr/nuvolaris/kind   
+  - |
+    # Download kind and setup a wrapper
+    VER="v0.14.0" ;\
+    ARCH="$(dpkg --print-architecture)" ;\
+    URL="https://github.com/kubernetes-sigs/kind/releases/download/$VER/kind-linux-$ARCH" ;\
+    wget $URL -O /usr/bin/kind.bin ;\
+    /usr/bin/echo -e '#!/bin/bash\nsudo env DOCKER_HOST=unix:///var/run/docker-host.sock /usr/bin/kind.bin "$@"' >/usr/bin/kind ;\
+    chmod +x /usr/bin/kind.bin /usr/bin/kind 
   - |
     # Download Kubeadm
     VER="v1.26.1" ;\

--- a/cloud-init.yaml
+++ b/cloud-init.yaml
@@ -80,7 +80,7 @@ runcmd:
     # Download nuv deb installer (which includes kind)
     rm -Rvf /tmp/nuv-installer ;\
     mkdir /tmp/nuv-installer ;\
-    BUILD="0.3.0-morpheus.23042210" ;\
+    BUILD="0.3.0-morpheus.23042311" ;\
     ARCH="$(dpkg --print-architecture)" ;\
     FILE="nuv_$(echo $BUILD)_$ARCH.deb" ;\
     URL="https://github.com/nuvolaris/nuv/releases/download/$BUILD/$FILE" ;\

--- a/cloud-init.yaml
+++ b/cloud-init.yaml
@@ -77,11 +77,19 @@ runcmd:
     wget "https://github.com/dandavison/delta/releases/download/0.11.2/$FILE" -O "/tmp/$FILE" ;\
     dpkg -i "/tmp/$FILE" ; rm "/tmp/$FILE"
   - |
-    # Download Kubectl
-    VER="v1.23.6" ;\
+    # Download nuv deb installer (which includes kind)
+    rm -Rvf /tmp/nuv-installer ;\
+    mkdir /tmp/nuv-installer ;\
+    BUILD="0.3.0-morpheus.23042210" ;\
     ARCH="$(dpkg --print-architecture)" ;\
-    URL="https://dl.k8s.io/release/$VER/bin/linux/$ARCH/kubectl" ;\
-    wget $URL -O /usr/bin/kubectl && chmod +x /usr/bin/kubectl
+    FILE="nuv_$(echo $BUILD)_$ARCH.deb" ;\
+    URL="https://github.com/nuvolaris/nuv/releases/download/$BUILD/$FILE" ;\
+    wget $URL -O "/tmp/nuv-installer/$FILE" ;\
+    dpkg -i "/tmp/nuv-installer/$FILE"
+    - |
+    # setup a kind wrapper
+    /usr/bin/echo -e '#!/bin/bash\nsudo env DOCKER_HOST=unix:///var/run/docker-host.sock /usr/nuvolaris/kind "$@"' >/usr/nuvolaris/kind ;\
+    chmod +x /usr/nuvolaris/kind   
   - |
     # Download Kubeadm
     VER="v1.26.1" ;\
@@ -94,14 +102,6 @@ runcmd:
     ARCH="$(dpkg --print-architecture)" ;\
     URL="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F$VER/kustomize_${VER}_linux_${ARCH}.tar.gz" ;\
     curl -sL "$URL" | tar xzvf - -C /usr/bin
-  - |
-    # Download kind and setup a wrapper
-    VER="v0.14.0" ;\
-    ARCH="$(dpkg --print-architecture)" ;\
-    URL="https://github.com/kubernetes-sigs/kind/releases/download/$VER/kind-linux-$ARCH" ;\
-    wget $URL -O /usr/bin/kind.bin ;\
-    /usr/bin/echo -e '#!/bin/bash\nsudo env DOCKER_HOST=unix:///var/run/docker-host.sock /usr/bin/kind.bin "$@"' >/usr/bin/kind ;\
-    chmod +x /usr/bin/kind.bin /usr/bin/kind
   - |
     # Download terraform
     ARCH="$(dpkg --print-architecture)" ;\
@@ -135,17 +135,7 @@ runcmd:
     cd /tmp/helm ;\
     tar -zxvf "helm-${VER}-linux-${ARCH}.tar.gz" ;\
     mv "./linux-${ARCH}/helm" /usr/bin/helm ;\
-    rm -Rvf /tmp/helm
-  - |
-    # Install minio-client
-    ARCH="$(dpkg --print-architecture)" ;\
-    MC_VER=RELEASE.2023-03-23T20-03-04Z; \
-    rm -Rvf /tmp/minio-binaries ;\
-    mkdir /tmp/minio-binaries ;\    
-    curl -sL "https://dl.min.io/client/mc/release/linux-${ARCH}/mc.${MC_VER}" --create-dirs -o /tmp/minio-binaries/mc ;\
-    chmod +x /tmp/minio-binaries/mc ;\
-    mv /tmp/minio-binaries/mc /usr/bin/mc;\
-    rm -Rvf /tmp/minio-binaries    
+    rm -Rvf /tmp/helm   
   - |
     # Download openshift okd installer
     VER=4.12.0-0.okd-2023-04-16-041331 ;\
@@ -174,14 +164,6 @@ runcmd:
     URL="https://github.com/carvel-dev/ytt/releases/download/v0.40.4/ytt-linux-$ARCH" ;\
     curl -sL "$URL" >/usr/bin/ytt ;\
     chmod +x /usr/bin/ytt
-  - |
-    # k3sup
-    VER=0.12.12 ;\
-    BASE=https://github.com/alexellis/k3sup/releases/download ;\
-    ARCH=-$(dpkg --print-architecture) ;\
-    if [[ $ARCH == "amd64" ]] ; then ARCH="" ; fi ;\
-    URL="$BASE/$VER/k3sup${ARCH}" ;\
-    curl -sL "$URL" >/usr/bin/k3sup ; chmod +x /usr/bin/k3sup
   - |
     # install kn
     VER="v1.4.1" ;\

--- a/setup.source
+++ b/setup.source
@@ -288,6 +288,7 @@ done
 if test -e $NUV_INSTALL_DIR
 then
     export PATH="$NUV_INSTALL_DIR:$PATH"
+    ok nuv
 else 
     ko $NUV_INSTALL_DIR    
 fi

--- a/setup.source
+++ b/setup.source
@@ -37,7 +37,7 @@ export JAVA_VERSION=8
 export PYENV_ROOT="$HOME/.pyenv"
 export NODENV_ROOT="$HOME/.nodenv"
 export GOENV_ROOT="$HOME/.goenv"
-export NUV_ROOT="/usr/nuvolaris"
+export NUV_INSTALL_DIR="/usr/nuvolaris"
 
 # git config
 export GIT_EDITOR=vim
@@ -285,12 +285,11 @@ do CMD="$(basename ${REF%%@*})"
 done
 
 # Check existence of nuv cli installed via deb and add it to the classpath
-if test -e $NUV_ROOT
+if test -e $NUV_INSTALL_DIR
 then
-    echo Adding $NUV_ROOT to PATH
-    export PATH="$NUV_ROOT:$PATH"
+    export PATH="$NUV_INSTALL_DIR:$PATH"
 else 
-    ko $NUV_ROOT    
+    ko $NUV_INSTALL_DIR    
 fi
 
 # replace

--- a/setup.source
+++ b/setup.source
@@ -37,6 +37,7 @@ export JAVA_VERSION=8
 export PYENV_ROOT="$HOME/.pyenv"
 export NODENV_ROOT="$HOME/.nodenv"
 export GOENV_ROOT="$HOME/.goenv"
+export NUV_ROOT="/usr/nuvolaris"
 
 # git config
 export GIT_EDITOR=vim
@@ -55,6 +56,10 @@ die() {
 
 ok() {
     echo OK: "$@"
+}
+
+ko() {
+    echo KO: "$@"
 }
 
 if ! which gcc >/dev/null
@@ -278,6 +283,15 @@ do CMD="$(basename ${REF%%@*})"
    else go install $REF
    fi
 done
+
+# Check existence of nuv cli installed via deb and add it to the classpath
+if test -e $NUV_ROOT
+then
+    echo Adding $NUV_ROOT to PATH
+    export PATH="$NUV_ROOT:$PATH"
+else 
+    ko $NUV_ROOT    
+fi
 
 # replace
 if ! which replace >/dev/null


### PR DESCRIPTION
This PR install nuv cli via a suitable deb package and adds /usr/nuvolaris into the PATH to include also nuv installed tools (kind, mc, k3sup etc etc)